### PR TITLE
Fix typo in videojs-playlists.js script location

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,7 +86,7 @@
     </div>
 </div>
 
-<script src="https://rawgithub.com/Belelros/videojs-playLists/master/lib/videojs-playlists.js" data-cover></script>
+<script src="https://raw.github.com/Belelros/videojs-playLists/master/lib/videojs-playlists.js" data-cover></script>
 <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
 <script src="js/main.js"></script>
 </body>


### PR DESCRIPTION
Tiny change. A missing . in script src was causing the demo not to run.
