### PR TITLE
Exposed more internal methods as external APIs

### DIFF
--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -40,11 +40,11 @@ function playList(options,arg){
       var aux = [];
       
       if (typeof videos[i].src == "string") {
-         aux.push({
+        aux.push({
           type: player.pl._guessVideoType(videos[i].src),
           src: videos[i].src
-         });
-       }
+        });
+      }
       else {
         for (var j = 0, len = videos[i].src.length; j < len; j++){
           aux.push({

--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -149,4 +149,8 @@ videojs.Player.prototype.getVideo = function(){
   return this.pl._getVideo();
 };
 
+videojs.Player.prototype.setVideoIndex = function(i){
+	this.pl._setVideo(i);
+}
+
 videojs.plugin('playList', playList);

--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -8,6 +8,7 @@ function playList(options,arg){
     var videoTypes = {
       'webm' : 'video/webm',
       'mp4' : 'video/mp4',
+      'mov' : 'video/mp4',
       'ogv' : 'video/ogg'
     };
     var extension = video.split('.').pop();

--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -163,4 +163,8 @@ videojs.Player.prototype.setVideoIndex = function(i){
   this.pl._setVideo(i);
 }
 
+videojs.Player.prototype.addVideos = function(videos) {
+  this.pl._addVideos(videos);
+}
+
 videojs.plugin('playList', playList);

--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -38,12 +38,22 @@ function playList(options,arg){
   player.pl._addVideos = function(videos){
     for (var i = 0, length = videos.length; i < length; i++){
       var aux = [];
-      for (var j = 0, len = videos[i].src.length; j < len; j++){
-        aux.push({
-          type : player.pl._guessVideoType(videos[i].src[j]),
-          src : videos[i].src[j]
-        });
+      
+      if (typeof videos[i].src == "string") {
+         aux.push({
+          type: player.pl._guessVideoType(videos[i].src),
+          src: videos[i].src
+         });
+       }
+      else {
+        for (var j = 0, len = videos[i].src.length; j < len; j++){
+          aux.push({
+            type : player.pl._guessVideoType(videos[i].src[j]),
+            src : videos[i].src[j]
+          });
+        }
       }
+      
       videos[i].src = aux;
       player.pl.videos.push(videos[i]);
     }
@@ -150,7 +160,7 @@ videojs.Player.prototype.getVideo = function(){
 };
 
 videojs.Player.prototype.setVideoIndex = function(i){
-	this.pl._setVideo(i);
+  this.pl._setVideo(i);
 }
 
 videojs.plugin('playList', playList);

--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -86,6 +86,15 @@ function playList(options,arg){
       }
     }
   };
+  
+  player.pl._getVideoIndex = function() {
+    return player.pl.current;
+  };
+
+  player.pl._getVideo = function() {
+    return player.pl.videos[player.pl.current];
+  };
+
 
   player.pl._setVideoSource = function(src, poster) {
     player.src(src);
@@ -130,6 +139,14 @@ videojs.Player.prototype.next = function(){
 videojs.Player.prototype.prev = function(){
   this.pl._nextPrev('prev');
   return this;
+};
+
+videojs.Player.prototype.getVideoIndex = function(){
+  return this.pl._getVideoIndex();
+};
+
+videojs.Player.prototype.getVideo = function(){
+  return this.pl._getVideo();
 };
 
 videojs.plugin('playList', playList);


### PR DESCRIPTION
Hi,

I've been using your plugin (it's great, btw!), I've made a few adjustments for my own application which you may or may not be interested in.

Mainly I've been adding public methods (getVideo, getVideoIndex, setVideoIndex, addVideos).
I've updated how the src of a video is parsed. It allows the caller to provide a simple string rather than an array (this was useful for me because I'm generating the json for the video list in Java, and it let me keep that Java class simpler).

I've also added a mapping from .mov to video/mp4
