### PR TITLE
allow passing type instead of guessing from src

### DIFF
--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -38,10 +38,15 @@ function playList(options,arg){
     for (var i = 0, length = videos.length; i < length; i++){
       var aux = [];
       for (var j = 0, len = videos[i].src.length; j < len; j++){
-        aux.push({
-          type : player.pl._guessVideoType(videos[i].src[j]),
-          src : videos[i].src[j]
-        });
+        var src = videos[i].src[j];
+        if (src.src && src.type) {
+          aux.push(src);
+        } else {
+          aux.push({
+            type: player.pl._guessVideoType(src),
+            src: src
+          });
+        }
       }
       videos[i].src = aux;
       player.pl.videos.push(videos[i]);


### PR DESCRIPTION
this allows to pass videos like this

``` js
videos = [
  {
    src : [
      {src: 'http://vjs.zencdn.net/v/oceans.wtf', type: 'video/whatever'},
      'http://vjs.zencdn.net/v/oceans.webm'
    ],
    poster : 'http://www.videojs.com/img/poster.jpg',
    title : 'Ocean'
  }
];
```
