### PR TITLE
Improve extension guessing when URL has parameters

### DIFF
--- a/lib/videojs-playlists.js
+++ b/lib/videojs-playlists.js
@@ -10,7 +10,7 @@ function playList(options,arg){
       'mp4' : 'video/mp4',
       'ogv' : 'video/ogg'
     };
-    var extension = video.split('.').pop();
+    var extension = video.replace(/\?.*$/, '').split('.').pop();
 
     return videoTypes[extension] || '';
   };


### PR DESCRIPTION
Extension guessing doesn't work at the moment when the URL has parameters
e.g. http://example.com/video.mp4?expires=1234567890
This will strip out the parameters before guessing the URL
