### PR TITLE
Added autoplayNext option to _videoEnd function

### DIFF
--- a/dist/videojs-playlists.js
+++ b/dist/videojs-playlists.js
@@ -108,7 +108,7 @@ function playList(options,arg){
     if (player.pl.current === player.pl.videos.length -1){
       player.trigger('lastVideoEnded');
     }
-    else {
+    else if (this.options().autoplayNext === true) {
       player.pl._resumeVideo();
       player.next();
     }


### PR DESCRIPTION
Handy if you don't want the playlist to move on it's own and you have your own prev/next functionality.
